### PR TITLE
feat(ci): add release please and fernignore

### DIFF
--- a/.fernignore
+++ b/.fernignore
@@ -1,1 +1,3 @@
 # Specify files that shouldn't be modified by Fern
+.github/workflows/release.yml
+.github/workflows/conventional-pr.yml

--- a/.github/workflows/conventional-pr.yml
+++ b/.github/workflows/conventional-pr.yml
@@ -1,0 +1,32 @@
+name: conventional-pr
+"on":
+  pull_request:
+    branches:
+      - main
+    types:
+      - opened
+      - edited
+      - synchronize
+jobs:
+  lint-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Generate a token
+        id: generate-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.SOFERAI_BOT_CLIENT_ID }}
+          private-key: ${{ secrets.SOFERAI_BOT_PRIVATE_SIGNING_KEY }}
+
+      - uses: CondeNast/conventional-pull-request-action@v0.2.0
+        env:
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
+        with:
+          # to override config-conventional rules, specify a relative path to your rules module, actions/checkout is required for this setting!
+          # commitlintRulesPath: './commitlint.rules.js' # default: undefined
+          # if the PR contains a single commit, fail if the commit message and the PR title do not match
+          commitTitleMatch: 'true' # default: 'true'
+          # if you squash merge PRs and enabled "Default to PR title for squash merge commits", you can disable all linting of commits
+          ignoreCommits: 'true' # default: 'false'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,70 @@
+# yamllint disable rule:line-length
+"on":
+    push:
+      branches:
+        - main
+  
+permissions:
+    contents: write
+    pull-requests: write
+
+name: release-please
+
+# env is a set of environment variables that are available to all jobs in the workflow.
+env:
+  RUFF_OUTPUT_FORMAT: github
+  PYTHON_VERSION: "3.12"
+
+jobs:
+  release-please:
+    runs-on: ubuntu-22.04
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
+      tag_name: ${{ steps.release.outputs.tag_name }}
+      major: ${{ steps.release.outputs.major }}
+      minor: ${{ steps.release.outputs.minor }}
+      patch: ${{ steps.release.outputs.patch }}
+
+    steps:
+    - name: Generate a token
+      id: generate-token
+      uses: actions/create-github-app-token@v1
+      with:
+        app-id: ${{ secrets.SOFERAI_BOT_CLIENT_ID }}
+        private-key: ${{ secrets.SOFERAI_BOT_PRIVATE_SIGNING_KEY }}
+
+    - uses: googleapis/release-please-action@v4
+      id: release
+      with:
+        token: ${{ steps.generate-token.outputs.token }}
+        release-type: python
+        # Setting target-branch allows us to track multiple release branches
+        # (should we need to maintain a 1.x or similar branch.)
+        target-branch: ${{ github.ref_name }}
+
+  pypi-publish:
+    name: upload release to PyPI
+    needs: release-please
+    if: ${{ needs.release-please.outputs.release_created }}
+    runs-on: ubuntu-22.04
+    # Specifying a GitHub environment is optional, but strongly encouraged
+    environment: pypi
+    permissions:
+      # IMPORTANT: this permission is mandatory for trusted publishing
+      id-token: write
+    steps:
+    # retrieve your distributions here
+    - uses: actions/checkout@v4
+
+    - uses: actions/setup-python@v5
+      with:
+        python-version: ${{ env.PYTHON_VERSION }}
+
+    - name: "Install uv"
+      run: curl -LsSf https://astral.sh/uv/install.sh | sh
+
+    # - name: Build with uv
+    #     run: uv build
+
+    # - name: Publish package distributions to PyPI
+    #     uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
This pull request introduces two new GitHub workflows and updates the `.fernignore` file to exclude these workflows from being modified by Fern. The changes aim to automate pull request linting and the release process.

### GitHub Workflows:

* [`.github/workflows/conventional-pr.yml`](diffhunk://#diff-3a413f41a65f1d2d87bbad3ae64589cb58cd62a412cf69d224087781f25952e2R1-R32): Added a new workflow to lint pull requests using the conventional pull request action. This workflow triggers on pull request events for the `main` branch.
* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R1-R70): Added a new workflow to automate the release process using the release-please action. This workflow is triggered on push events to the `main` branch and includes steps for generating a token, creating a release, and publishing to PyPI.

### Configuration Updates:

* [`.fernignore`](diffhunk://#diff-1d1faedb42b688856df4b129efebd1c46258654889c3d58f49f07ce6d4962f14R2-R3): Updated to exclude the new workflow files from being modified by Fern.