### PR TITLE
fix: set httpx dependency to something supabase can handle

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "httpx>=0.28.1",
+    "httpx>=0.27.2",
     "pydantic>=2.10.4",
     "pydantic-core>=2.27.2",
     "typing-extensions>=4.12.2",

--- a/uv.lock
+++ b/uv.lock
@@ -456,7 +456,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "httpx", specifier = ">=0.28.1" },
+    { name = "httpx", specifier = ">=0.27.2" },
     { name = "pydantic", specifier = ">=2.10.4" },
     { name = "pydantic-core", specifier = ">=2.27.2" },
     { name = "typing-extensions", specifier = ">=4.12.2" },


### PR DESCRIPTION
This pull request includes a small change to the `pyproject.toml` file. The change downgrades the `httpx` dependency from version 0.28.1 to version 0.27.2.

* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L33-R33): Downgraded the `httpx` dependency from `0.28.1` to `0.27.2`.