### PR TITLE
fix: add renovate.json to fernignore

### DIFF
--- a/.fernignore
+++ b/.fernignore
@@ -20,3 +20,4 @@ uv.lock
 pyproject.toml
 .python-version
 CHANGELOG.md
+renovate.json


### PR DESCRIPTION
This pull request includes a small change to the `.fernignore` file. The change adds `renovate.json` to the list of ignored files.